### PR TITLE
chore: remove parallel tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ addopts = [
     "--no-cov-on-fail",
     "--cov-fail-under=100",
     "--cov-report=term-missing",
-    "--numprocesses=auto",
     "--tb=short",
 ]
 


### PR DESCRIPTION
Remove parallel tests by default. You can still run tests in parallel manually with the -n <num> flag.